### PR TITLE
Update tdl-load-files to break on double Scenario+Runner id calls

### DIFF
--- a/cosmotech/orchestrator_plugins/csm-data/templates/tdl_load_files.json
+++ b/cosmotech/orchestrator_plugins/csm-data/templates/tdl_load_files.json
@@ -9,9 +9,7 @@
     "--organization-id",
     "$CSM_ORGANIZATION_ID",
     "--workspace-id",
-    "$CSM_WORKSPACE_ID",
-    "--runner-id",
-    "$CSM_RUNNER_ID"
+    "$CSM_WORKSPACE_ID"
   ],
   "description": "Use csm-data to query a twingraph and loads all the data from it",
   "useSystemEnvironment": true,


### PR DESCRIPTION
Scenarios and Runners are mutually exclusive, there should never be a case where both are defined so it should break instead of accepting whatever is happenning