### PR TITLE
Update pyarrow to version 20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ singlestoredb~=1.10.0
 cosmotech-run-orchestrator~=2.0.0
 
 # Data store requirements
-pyarrow~=17.0.0
+pyarrow~=20.0.0
 adbc-driver-manager~=1.1.0
 adbc-driver-sqlite~=1.1.0
 adbc-driver-postgresql~=1.1.0


### PR DESCRIPTION
This version supports Python 3.13 (with a pre-packaged wheel) which we'll need soon as it will be the default version on the upcoming Debian 13