### PR TITLE
fix: update foreign key constraints and ensure uniqueness in runner metadata

### DIFF
--- a/cosmotech/coal/postgresql/runner.py
+++ b/cosmotech/coal/postgresql/runner.py
@@ -57,14 +57,13 @@ def send_runner_metadata_to_postgresql(
             curs.execute(sql_create_table)
             conn.commit()
 
-            last_run_id = runner.get("lastRunInfo").get("lastRunId")
-            if last_run_id:
-                sql_delete_from_metatable = f"""
-                    DELETE FROM {schema_table}
-                    WHERE last_csm_run_id= $1;
-                """
-                curs.execute(sql_delete_from_metatable, (last_run_id,))
-                conn.commit()
+            runner_id = runner.get("id")
+            sql_delete_from_metatable = f"""
+                DELETE FROM {schema_table}
+                WHERE id= $1;
+            """
+            curs.execute(sql_delete_from_metatable, (runner_id,))
+            conn.commit()
 
             sql_upsert = f"""
                 INSERT INTO {schema_table} (id, name, last_csm_run_id, run_template_id)

--- a/cosmotech/coal/postgresql/runner.py
+++ b/cosmotech/coal/postgresql/runner.py
@@ -67,10 +67,7 @@ def send_runner_metadata_to_postgresql(
 
             sql_upsert = f"""
                 INSERT INTO {schema_table} (id, name, last_csm_run_id, run_template_id)
-                  VALUES ($1, $2, $3, $4)
-                  ON CONFLICT (id)
-                  DO
-                    UPDATE SET name = EXCLUDED.name, last_csm_run_id = EXCLUDED.last_csm_run_id;
+                VALUES ($1, $2, $3, $4)
             """
             LOGGER.debug(runner)
             curs.execute(

--- a/cosmotech/coal/postgresql/runner.py
+++ b/cosmotech/coal/postgresql/runner.py
@@ -56,6 +56,16 @@ def send_runner_metadata_to_postgresql(
             LOGGER.info(T("coal.services.postgresql.creating_table").format(schema_table=schema_table))
             curs.execute(sql_create_table)
             conn.commit()
+
+            last_run_id = runner.get("lastRunInfo").get("lastRunId")
+            if last_run_id:
+                sql_delete_from_metatable = f"""
+                    DELETE FROM {schema_table}
+                    WHERE last_csm_run_id= $1;
+                """
+                curs.execute(sql_delete_from_metatable, (last_run_id,))
+                conn.commit()
+
             sql_upsert = f"""
                 INSERT INTO {schema_table} (id, name, last_csm_run_id, run_template_id)
                   VALUES ($1, $2, $3, $4)

--- a/cosmotech/coal/postgresql/runner.py
+++ b/cosmotech/coal/postgresql/runner.py
@@ -49,7 +49,7 @@ def send_runner_metadata_to_postgresql(
                 CREATE TABLE IF NOT EXISTS {schema_table}  (
                   id varchar(32) PRIMARY KEY,
                   name varchar(256),
-                  last_csm_run_id varchar(32),
+                  last_csm_run_id varchar(32) UNIQUE,
                   run_template_id varchar(32)
                 );
             """

--- a/cosmotech/coal/postgresql/store.py
+++ b/cosmotech/coal/postgresql/store.py
@@ -115,7 +115,7 @@ def dump_store_to_postgresql_from_conf(
             )
             if fk_id and _psql.is_metadata_exists():
                 metadata_table = f"{_psql.metadata_table_name}"
-                _psql.add_fk_constraint(table_name, "csm_run_id", metadata_table, "last_csm_run_id")
+                _psql.add_fk_constraint(target_table_name, "csm_run_id", metadata_table, "last_csm_run_id")
 
             total_rows += rows
             _up_time = perf_counter()

--- a/cosmotech/coal/postgresql/utils.py
+++ b/cosmotech/coal/postgresql/utils.py
@@ -155,12 +155,23 @@ class PostgresUtils:
         to_table: str,
         to_col: str,
     ) -> None:
-        # Connect to PostgreSQL and remove runner metadata row
+        # Connect to PostgreSQL and add a foreign key constraint
         with dbapi.connect(self.full_uri, autocommit=True) as conn:
             with conn.cursor() as curs:
                 sql_add_fk = f"""
-                    ALTER TABLE {self.db_schema}.{from_table}
-                    CONSTRAINT metadata FOREIGN KEY ({from_col}) REFERENCES {to_table}({to_col})
+                    DO $$
+                    BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1
+                            FROM pg_constraint
+                            WHERE conname = 'metadata'
+                              AND conrelid = '{self.db_schema}.{from_table}'::regclass
+                        ) THEN
+                            ALTER TABLE {self.db_schema}.{from_table}
+                            ADD CONSTRAINT metadata FOREIGN KEY ({from_col})
+                            REFERENCES {self.db_schema}.{to_table}({to_col});
+                        END IF;
+                    END $$;
                 """
                 curs.execute(sql_add_fk)
                 conn.commit()

--- a/cosmotech/coal/postgresql/utils.py
+++ b/cosmotech/coal/postgresql/utils.py
@@ -169,7 +169,8 @@ class PostgresUtils:
                         ) THEN
                             ALTER TABLE {self.db_schema}.{from_table}
                             ADD CONSTRAINT metadata FOREIGN KEY ({from_col})
-                            REFERENCES {self.db_schema}.{to_table}({to_col});
+                            REFERENCES {self.db_schema}.{to_table}({to_col})
+                            ON DELETE CASCADE;
                         END IF;
                     END $$;
                 """

--- a/tests/unit/coal/test_postgresql/test_postgresql_runner.py
+++ b/tests/unit/coal/test_postgresql/test_postgresql_runner.py
@@ -72,14 +72,19 @@ class TestRunnerFunctions:
         mock_connect.assert_called_once_with("postgresql://user:password@localhost:5432/testdb", autocommit=True)
 
         # Check that SQL statements were executed
-        assert mock_cursor.execute.call_count == 2
+        assert mock_cursor.execute.call_count == 3
 
         # Verify the SQL statements (partially, since the exact SQL is complex)
         create_table_call = mock_cursor.execute.call_args_list[0]
         assert "CREATE TABLE IF NOT EXISTS" in create_table_call[0][0]
         assert "public.test_runnermetadata" in create_table_call[0][0]
 
-        upsert_call = mock_cursor.execute.call_args_list[1]
+        delete_call = mock_cursor.execute.call_args_list[1]
+        assert "DELETE FROM" in delete_call[0][0]
+        assert "public.test_runnermetadata" in delete_call[0][0]
+        assert delete_call[0][1] == ("test-run-id",)
+
+        upsert_call = mock_cursor.execute.call_args_list[2]
         assert "INSERT INTO" in upsert_call[0][0]
         assert "public.test_runnermetadata" in upsert_call[0][0]
         assert upsert_call[0][1] == (
@@ -90,7 +95,7 @@ class TestRunnerFunctions:
         )
 
         # Check that commits were called
-        assert mock_conn.commit.call_count == 2
+        assert mock_conn.commit.call_count == 3
 
         # Verify the function returns the lastRunId
         assert result == "test-run-id"

--- a/tests/unit/coal/test_postgresql/test_postgresql_runner.py
+++ b/tests/unit/coal/test_postgresql/test_postgresql_runner.py
@@ -82,7 +82,7 @@ class TestRunnerFunctions:
         delete_call = mock_cursor.execute.call_args_list[1]
         assert "DELETE FROM" in delete_call[0][0]
         assert "public.test_runnermetadata" in delete_call[0][0]
-        assert delete_call[0][1] == ("test-run-id",)
+        assert delete_call[0][1] == ("test-runner-id",)
 
         upsert_call = mock_cursor.execute.call_args_list[2]
         assert "INSERT INTO" in upsert_call[0][0]


### PR DESCRIPTION
This pull request fixes several issues identified in COAL, specifically in the part responsible for sending data to PostgreSQL.

These issues are mainly related to the function that creates the link between the comsotech_runmetadata table and the result tables exported to PostgreSQL.

- First issue: there was a syntax error in the statement used to define the foreign key constraint. The ADD keyword was missing in the ALTER TABLE statement when declaring the constraint.

- Second issue: the foreign key constraint was being added to the wrong table name, without the expected prefix. For example, it targeted mytable instead of cosmotech_mytable by default.

- Third issue: the last_csm_run_id column was missing a uniqueness constraint, which caused the creation of the foreign key constraint to fail.

- Fourth issue: the code did not check whether the foreign key constraint already existed before attempting to create it. As a result, each write operation tried to recreate the constraint, which is not allowed by PostgreSQL.

- Fifth and final issue: when the same scenario was executed two or more times, data from the previous run was not deleted. This caused the insertion query into the runner_metadata table to fail because of the uniqueness constraint.

Each of these issues has been fixed and tested in a development environment.

However, some cases are still not handled, such as deleting a scenario, which currently does not remove the related data from the database.

One important remaining point is that we need to find an efficient way to test all these behaviors through integration tests directly in COAL.